### PR TITLE
fix: Remove outdated Quick Start SQL from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,9 @@ snowflake-intelligence-custom-tools/
 - ✅ Comprehensive error handling
 
 **Quick Start:**
-```sql
--- 1. Create infrastructure (one-time setup)
-CREATE TABLE SNOWFLAKE_INTELLIGENCE.PUBLIC.TEMP_CSV (csv_data STRING);
-CREATE STAGE SNOWFLAKE_INTELLIGENCE.PUBLIC.TEMP_FILES;
-
--- 2. Deploy procedure (see csv-download-tool/ folder)
--- 3. Configure in Snowflake Intelligence UI
--- 4. Users can now request CSV downloads!
-```
+- 📖 Read the complete setup guide in [`csv-download-tool/README.md`](./csv-download-tool/README.md)
+- 🚀 Follow the deployment checklist in [`csv-download-tool/deployment_checklist.md`](./csv-download-tool/deployment_checklist.md)
+- ⚙️ Configure the tool using [`csv-download-tool/snowflake_intelligence_setup_guide.md`](./csv-download-tool/snowflake_intelligence_setup_guide.md)
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
## 🧹 README Cleanup

Removes outdated Quick Start SQL commands from the main README.md to prevent confusion and direct users to comprehensive documentation.

## 🔧 Changes Made

**Removed:**
```sql
-- 1. Create infrastructure (one-time setup)
CREATE TABLE SNOWFLAKE_INTELLIGENCE.PUBLIC.TEMP_CSV (csv_data STRING);
CREATE STAGE SNOWFLAKE_INTELLIGENCE.PUBLIC.TEMP_FILES;

-- 2. Deploy procedure (see csv-download-tool/ folder)
-- 3. Configure in Snowflake Intelligence UI
-- 4. Users can now request CSV downloads!
```

**Replaced with:**
- 📖 Read the complete setup guide in `csv-download-tool/README.md`
- 🚀 Follow the deployment checklist in `csv-download-tool/deployment_checklist.md`
- ⚙️ Configure the tool using `csv-download-tool/snowflake_intelligence_setup_guide.md`

## 💡 Why This Fix is Important

1. **Prevents Confusion**: The old SQL used deprecated schema without session isolation
2. **Accurate Documentation**: Directs users to up-to-date comprehensive guides
3. **Better UX**: Users get complete setup information instead of incomplete snippets
4. **Consistency**: All setup instructions are now in detailed tool-specific docs

## ✅ Impact

- Main README now properly directs to comprehensive documentation
- No more outdated schema references (missing session_id and SSE encryption)
- Users follow proper setup flow with enhanced table schema and security features

This ensures users get the correct, complete setup information for the enhanced CSV tool with session-based isolation.